### PR TITLE
Fix: Correct display of the 'il' character in Google Chrome search

### DIFF
--- a/QTatar/Sources/KeyboardKit/Layout/InputSet.swift
+++ b/QTatar/Sources/KeyboardKit/Layout/InputSet.swift
@@ -37,7 +37,7 @@ public extension InputSet {
     static var qwerty: InputSet {
         .init(rows: [
             .init(chars: "qwertyuıopğü"),
-            .init(chars: "asdfghjklşi̇ñ"),
+            .init(lowercased: "asdfghjklşiñ", uppercased: "ASDFGHJKLŞİÑ"),
             .init(phone: "zxcvbnmöçâ", pad: "zxcvbnmöçâ,")
         ])
     }


### PR DESCRIPTION
The issue was that the lowercase and uppercase versions of the character were displayed differently. The problem has been resolved by using uppercase and lowercase characters explicitly with the appropriate case handling. 

Path to the file: Keyboard/QTatar/Sources/KeyboardKit/Layout/InputSet.swift.