### PR TITLE
Fix action count validation for iPhone layout

### DIFF
--- a/QTatar/Sources/KeyboardKit/Layout/Providers/iPhoneKeyboardLayoutProvider.swift
+++ b/QTatar/Sources/KeyboardKit/Layout/Providers/iPhoneKeyboardLayoutProvider.swift
@@ -188,19 +188,19 @@ private extension iPhoneKeyboardLayoutProvider {
         if [.numeric, .symbolic].contains(context.keyboardType) {
             return actions.count == 3
         }
-        return actions.count == 3 // TODO, INFO: Shrinked ugly 4 rows error when set actions.count == 3, so set actions.count == 4
+        return actions.count == 4
     }
     
     func isExpectedNumericActionSet(
         _ actions: KeyboardAction.Rows
     ) -> Bool {
-        return actions.count == 3 // TODO, INFO: Shrinked ugly 3 rows error when set actions.count == 4, so set actions.count == 3
+        return actions.count == 3
     }
-    
+
     func isExpectedLetterActionSet(
         _ actions: KeyboardAction.Rows
     ) -> Bool {
-        return actions.count == 3 // TODO, INFO: Shrinked ugly 4 rows error when set actions.count == 3, so set actions.count == 4
+        return actions.count == 4
     }
 
     func isPortrait(


### PR DESCRIPTION
## Summary
- correct `isExpectedActionSet` logic to expect four action rows for alphabetic keyboards
- adjust helper functions accordingly

## Testing
- `swift test | head -n 20` *(fails: cannot find type 'Selector' in scope)*

------
https://chatgpt.com/codex/tasks/task_e_684bdae8e6a08324ac7886cec2fbc2bc